### PR TITLE
hostname module already sets /etc/hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,30 @@ Ansible role for manage the hostname
 
 #### Variables
 
-THe role variables and default values.
+The role variables and default values.
 
 ```yaml
 hostname_enabled: yes                       # Enable module
 hostname_hostname: "{{inventory_hostname}}" # Set hostname
 hostname_hostname_short: "{{hostname_hostname.split('.')[:-1]|join('.')}}" # Set short hostname
 ```
+
+#### Requirements
+
+If /etc/hostname has *not* already been created by the installer
+(e.g. a debootstrap system), AND you have already set an unusually
+restrictive umask, then /etc/hostname could be created with
+unusually restrictive permissions.  Try not to do that.
+
+This would probably only cause obscure, unusual (difficult to troubleshoot :)
+problems.  /etc/hostname is only expected to be used by privileged software
+at boot time.  Most other software should query the kernel value which the
+boot software set up, i.e. gethostname().
+
+This is a limitation in the Ansible hostname module (as of v2.3.1).
+It does not enforce standard permissions for /etc/hostname.
+We don't try to set permissions ourself because some distributions use
+a different config file than /etc/hostname.
 
 #### License
 

--- a/tasks/hostname.yml
+++ b/tasks/hostname.yml
@@ -1,9 +1,6 @@
 - name: Update hostname
   hostname: name="{{hostname_hostname}}"
 
-- name: Update /etc/hostname
-  template: src=hostname.j2 dest=/etc/hostname owner=root group=root mode=0644
-
 - name: Update /etc/hosts pt. 1 
   lineinfile:
     dest: /etc/hosts

--- a/templates/hostname.j2
+++ b/templates/hostname.j2
@@ -1,1 +1,0 @@
-{{hostname_hostname}}


### PR DESCRIPTION
The hostname module already sets /etc/hostname.
Or the file in /etc/sysconfig/whatever for old RedHat.
And if it doesn't know how to handle the distibution,
the hostname module will fail anyway.

Caveat: this means we no longer enforce correct permissions on
/etc/hostname.  This is significant if the user already configured a
restrictive umask, because the hostname module doesn't account for that.
Document it.